### PR TITLE
TASK-4.8: add aspect ratio for SightCard, SightListScreen rework AppBar to PreferrdSize

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:places/gen/fonts.gen.dart';
-import 'package:places/mocks.dart';
 import 'package:places/ui/res/constants/strings.dart';
-import 'package:places/ui/screen/sight_details.dart';
+import 'package:places/ui/screen/sight_list_screen.dart';
 
 void main() {
   runApp(const App());
@@ -21,8 +20,9 @@ class App extends StatelessWidget {
         primarySwatch: Colors.blueGrey,
         fontFamily: FontFamily.roboto,
       ),
-      home: SafeArea(
-        child: SightDetails(item: mocks[0]), // or SightListScreen()
+      home: const SafeArea(
+        child: SightListScreen(),
+        // child: SightDetails(item: mocks[0]), // or SightListScreen()
       ),
     );
   }

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -14,84 +14,92 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(12),
-      child: ColoredBox(
-        color: ColorName.background,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Stack(
-              fit: StackFit.passthrough,
-              children: [
-                Container(
-                  height: thumbHeight,
-                  decoration: BoxDecoration(
-                    color: ColorName.white,
-                    image: DecorationImage(
-                      fit: BoxFit.cover,
-                      image: NetworkImage(
-                        item.url,
-                      ),
-                    ),
-                  ),
-                ),
-                Opacity(
-                  opacity: 0.4,
-                  child: Container(
+    return AspectRatio(
+      aspectRatio: 3.0 / 2.0,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: ColoredBox(
+          color: ColorName.background,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Stack(
+                fit: StackFit.passthrough,
+                children: [
+                  Container(
                     height: thumbHeight,
                     decoration: BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          ColorName.main,
-                          ColorName.secondary.withOpacity(0.08),
-                        ],
+                      color: ColorName.white,
+                      image: DecorationImage(
+                        fit: BoxFit.cover,
+                        image: NetworkImage(
+                          item.url,
+                        ),
                       ),
                     ),
                   ),
-                ),
-                Container(
-                  padding: const EdgeInsets.all(16),
-                  child: Text(
-                    item.type,
-                    style: AppTypography.smallBold.copyWith(
+                  Opacity(
+                    opacity: 0.4,
+                    child: Container(
+                      height: thumbHeight,
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [
+                            ColorName.main,
+                            ColorName.secondary.withOpacity(0.08),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    child: Text(
+                      item.type,
+                      style: AppTypography.smallBold.copyWith(
+                        color: ColorName.white,
+                      ),
+                    ),
+                  ),
+                  const Positioned(
+                    top: 16,
+                    right: 16,
+                    child: Icon(
+                      Icons.favorite_border_outlined,
                       color: ColorName.white,
-                    ),
-                  ),
-                ),
-                const Positioned(
-                  top: 16,
-                  right: 16,
-                  child: Icon(
-                    Icons.favorite_border_outlined,
-                    color: ColorName.white,
-                  ),
-                ),
-              ],
-            ),
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    item.name,
-                    style: AppTypography.text.copyWith(
-                      color: ColorName.secondary,
-                    ),
-                  ),
-                  Text(
-                    item.details,
-                    style: AppTypography.small.copyWith(
-                      color: ColorName.secondary2,
                     ),
                   ),
                 ],
               ),
-            ),
-          ],
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: 16,
+                  right: 16,
+                  bottom: 16,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      item.name,
+                      style: AppTypography.text.copyWith(
+                        color: ColorName.secondary,
+                      ),
+                    ),
+                    Text(
+                      item.details,
+                      style: AppTypography.small.copyWith(
+                        color: ColorName.secondary2,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -30,15 +30,21 @@ class TextWithStyle extends StatelessWidget {
 class _SightListScreenState extends State<SightListScreen> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
+    return const Scaffold(
       resizeToAvoidBottomInset: false,
-      appBar: AppBar(
-        toolbarHeight: 112.0,
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        title: const TextWithStyle(),
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(128.0),
+        child: Padding(
+          padding: EdgeInsets.only(
+            left: 16.0,
+            right: 16.0,
+            top: 40.0,
+            bottom: 16.0,
+          ),
+          child: TextWithStyle(),
+        ),
       ),
-      body: const SingleChildScrollView(
+      body: SingleChildScrollView(
         child: _SightCards(),
       ),
     );
@@ -50,18 +56,20 @@ class _SightCards extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: mocks
-          .map(
-            (item) => Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 16.0,
-                vertical: 8.0,
-              ),
-              child: SightCard(item: item),
-            ),
-          )
-          .toList(),
+    return Padding(
+      padding: const EdgeInsets.only(
+        left: 16.0,
+        right: 16.0,
+        bottom: 16.0,
+      ),
+      child: Wrap(
+        runSpacing: 16,
+        children: mocks
+            .map(
+              (item) => SightCard(item: item),
+            )
+            .toList(),
+      ),
     );
   }
 }


### PR DESCRIPTION
Размер Текстового виджета поменялся, потому что мы задали ограничение через `ConstraintedBox`. В данном случае он смотрит ограничения родителя, то есть `ConstraintedBox`. 

Для вычитаемого значения по ширине родительского виджета можно использовать несколько вариантов, самые удачные на мой взгляд это использовать `LayoutBuilder`, где в билдере вторым аргументом можно получить constraints. Далее в нужном нам месте ниже по дереву используя `ConstraintedBox` указать например
```
ConstraintedBox(
    constraints: BoxConstraints.tightFor( width: constraints.maxWidth / 2 ),
    child: Text(‘Some Text’),
)
```
и получить половину ширины родительского виджета.

И второй вариант `FractionallySizedBox`, он более прост в использовании нежели первый вариант. `FractionallySizedBox` при создании использует метод `createRenderObject`, где происходит вызов алгоритма компоновки `RenderFractionallySizedOverflowBox`.

Для использования необходимо указать параметр `widthFactor` который напрямую зависит от доступного пространства( 100% = 1 ), в данном случае от ширины и будет влиять на дочерний элемент.
```
FractionallySizedBox(
    widthFactor: 0.5,
    child: Text(‘Some Text’),
)
```

Было бы хорошо узнать какой из вариантов более производительный.


- Переверстать AppBar через наследника PreferredSizeWidget.

Что `AppBar`, что `PreferedSize` уже реализуют в своем классе `PreferredSizeWidget`. Поэтому использовать `AppBar` как `child` в `PreferedSize` избыточно.

![photo_2022-08-10 22 23 05](https://user-images.githubusercontent.com/8302209/183943272-ed2ab604-b59d-4d14-b1bf-b0e200b7db28.jpeg)


